### PR TITLE
areAtLeast will take predicate as non-optional parameter

### DIFF
--- a/assertk-common/src/main/kotlin/assertk/assertions/predicate.kt
+++ b/assertk-common/src/main/kotlin/assertk/assertions/predicate.kt
@@ -15,12 +15,7 @@ import assertk.assertions.support.show
  * ```
  */
 
-fun <E, T : Iterable<E>> Assert<T>.areAtLeast(times: Int, f: ((E) -> Any)? = null) {
-    var count = 0
-    if (f == null) expected("condition should be not null")
-    actual.forEach { item ->
-        if (f?.let { it(item!!) } == true) count++
-    }
-    if (count >= times) return
+fun <E, T : Iterable<E>> Assert<T>.areAtLeast(times: Int, f: ((E) -> Boolean)) {
+    if (actual.filter { f(it) }.size >= times) return
     expected("atleast $times occurences in ${show(actual)}")
 }

--- a/assertk-common/src/test/kotlin/test/assertk/assertions/PredicateTest.kt
+++ b/assertk-common/src/test/kotlin/test/assertk/assertions/PredicateTest.kt
@@ -29,13 +29,4 @@ class PredicateTest {
     @Test fun least_expectancy_met_inline_condition_passes() {
         assert(listOf(1, 2, 3) as Iterable<Int>).areAtLeast(2) { listOf(1, 2, 3).contains(it) }
     }
-
-    @Test fun condition_empty_fails() {
-        val error = assertFails {
-            assert(listOf(5, 2, 3) as Iterable<Int>).areAtLeast(2)
-        }
-        assertEquals("expected condition should be not null", error.message)
-
-    }
-
 }


### PR DESCRIPTION
Tasks:
1. areAtLeast will take predicate as non-optional parameter
2. predicate function will return Boolean instead of Any
3. Using functional way to find the number of matches